### PR TITLE
Added memory usage table in readme and bash scripts for building and running docker from terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Whole-Body Humanoid MPC
 
-This repository contains a Whole-Body Nonlinear Model Predictive Controller (NMPC) for humanoid loco-manipulation control. This approach enables to directly optimize through the **full-order torque-level dynamics in realtime** to generate a wide range of humanoid behaviors building up on an [extended & updated version of ocs2](https://github.com/manumerous/ocs2_ros2)
+This repository contains a Whole-Body Nonlinear Model Predictive Controller (NMPC) for humanoid loco-manipulation control. This approach enables to directly optimize through the **full-order torque-level dynamics in realtime** to generate a wide range of humanoid behaviors building up on an [updated version of ocs2](https://github.com/manumerous/ocs2_ros2)
 
 **Interactive Velocity and Base Height Control via Joystick:**
 ![Screencast2024-12-16180254-ezgif com-optimize(3)](https://github.com/user-attachments/assets/d4b1f0da-39ca-4ce1-b53c-e1d040abe1be)
@@ -46,7 +46,7 @@ The project supports both Dockerized workspaces (recommended) or a local install
 <details>
 <summary>Dockerized Workspace</summary>
 
-We provide a [Dockerfile](https://github.com/manumerous/wb_humanoid_mpc/blob/main/docker/Dockerfile) to enable running and devloping the project from a containerized environment. Check out the [devcontainer.json](https://github.com/manumerous/wb_humanoid_mpc/blob/main/.devcontainer/devcontainer.json) for the arguments that must be supplied to the `docker build` and `docker run` commands. 
+We provide a [Dockerfile](https://github.com/manumerous/wb_humanoid_mpc/blob/main/docker/Dockerfile) to enable running and devloping the project from a containerized environment. Check out the [devcontainer.json](https://github.com/manumerous/wb_humanoid_mpc/blob/main/.devcontainer/devcontainer.json) for the arguments that must be supplied to the `docker build` and `docker run` commands. This repository includes two helper scripts:`image_build.bash` builds the `wb-humanoid-mpc:dev` Docker image using the arguments defined in `devcontainer.json`. `launch_wb_mpc.bash` starts the Docker container, mounts your workspace, and drops you into a Bash shell ready to build and run the WB Humanoid MPC code.
 
 For working in **Visual Studio Code**, we recommend to install the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension. Then, with the root of this repository as the root of your VS Code workspace, enter `Ctrl + Shift + P` and select `Dev Containers: Rebuild and Reopen in Container` at the top of the screen. VS Code will then automatically handle calling the `docker build` and `docker run` commands for you and will reopen the window at the root of the containerized workspace. Once this step is completed, you are ready to [build and run the code](https://github.com/manumerous/wb_humanoid_mpc/tree/main?tab=readme-ov-file#building-the-mpc).
 
@@ -64,6 +64,18 @@ Then install all dependencies using:
 envsubst < dependencies.txt | xargs sudo apt install -y
 ```
 </details>
+
+## Build RAM Usage by PARALLEL_JOBS
+
+| PARALLEL_JOBS | Peak RAM Used | System Response                                    |
+|--------------:|--------------:|----------------------------------------------------|
+| 1             | 11 GiB        | Completed cleanly                                  |
+| 2             | 14 GiB        | Hung for ~5–7 min, then resumed                    |
+| 4             | 14 GiB        | Froze completely → needed forced power‑off         |
+| 6             | 14 GiB        | Froze completely → needed forced power‑off         |
+
+> **Note:** All of these builds were attempted inside a VS Code Dev Container but kept crashing. The image was therefore built and run **from a terminal** Docker session, and all RAM measurements come from terminal‑based setup.
+> Tested on: HP Victus (i5‑11400H, RTX 3050, Ubuntu 22.04, 16 GB RAM)
 
 ### Building the MPC 
 

--- a/image_build.bash
+++ b/image_build.bash
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# image_build.bash - Build the WB Humanoid MPC Docker image
+# Reflects the "build" section of .devcontainer/devcontainer.json
+set -euo pipefail
+
+# Paths (relative to this script)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Assumes this script is in the project root; adjust if needed
+CONTEXT="${SCRIPT_DIR}"
+DOCKERFILE="${SCRIPT_DIR}/docker/Dockerfile"
+TARGET="base"
+
+# Build arguments (from devcontainer.json)
+: "# Workspace directory inside container"
+WB_HUMANOID_MPC_DIR="/wb_humanoid_mpc_ws"
+PYTHON_VERSION="3.12"
+USER_ID="$(id -u)"
+GROUP_ID="$(id -g)"
+GIT_USER_NAME="$(git config --global user.name || echo '')"
+GIT_USER_EMAIL="$(git config --global user.email || echo '')"
+
+# Image tag
+IMAGE_TAG="wb-humanoid-mpc:dev"
+
+# Build command
+docker build \
+  --file "${DOCKERFILE}" \
+  --target "${TARGET}" \
+  --build-arg WB_HUMANOID_MPC_DIR="${WB_HUMANOID_MPC_DIR}" \
+  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" \
+  --build-arg USER_ID="${USER_ID}" \
+  --build-arg GROUP_ID="${GROUP_ID}" \
+  --build-arg GIT_USER_NAME="${GIT_USER_NAME}" \
+  --build-arg GIT_USER_EMAIL="${GIT_USER_EMAIL}" \
+  --tag "${IMAGE_TAG}" \
+  "${CONTEXT}"
+
+echo "Built image: ${IMAGE_TAG}"

--- a/launch_wb_mpc.bash
+++ b/launch_wb_mpc.bash
@@ -15,7 +15,7 @@ if [ ! -f "${XAUTH}" ]; then
 fi
 
 # Host workspace root (hard‑coded)
-HOST_WS="./humanoid_mpc_ws"        # your workspace root
+HOST_WS="$(realpath "${PWD}/../..")" # your workspace root
 BUILD_WS="${HOST_WS}/build"
 INSTALL_WS="${HOST_WS}/install"
 

--- a/launch_wb_mpc.bash
+++ b/launch_wb_mpc.bash
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Allow GUI applications
+xhost +SI:localuser:root
+
+# Generate Xauthority file for X11 forwarding
+XAUTH=/tmp/.docker.xauth
+if [ ! -f "${XAUTH}" ]; then
+  touch "${XAUTH}"
+  xauth nlist "${DISPLAY}" \
+    | sed -e 's/^..../ffff/' \
+    | xauth -f "${XAUTH}" nmerge -
+  chmod a+r "${XAUTH}"
+fi
+
+# Host workspace root (hard‑coded)
+HOST_WS="./humanoid_mpc_ws"        # your workspace root
+BUILD_WS="${HOST_WS}/build"
+INSTALL_WS="${HOST_WS}/install"
+
+# Run the container, mounting the entire workspace
+# Bind mounts: src/, build/, and install/ persist on host
+
+docker run --rm -it \
+  --name wb-mpc-dev \
+  --gpus all \
+  --net host \
+  --privileged \
+  -u root \
+  -e DISPLAY \
+  -e QT_X11_NO_MITSHM=1 \
+  -e XAUTHORITY="${XAUTH}" \
+  -e XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp}" \
+  -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
+  -v "${XAUTH}:${XAUTH}:rw" \
+  -v "${HOST_WS}:/wb_humanoid_mpc_ws:cached" \
+  -v "${BUILD_WS}:/wb_humanoid_mpc_ws/build:cached" \
+  -v "${INSTALL_WS}:/wb_humanoid_mpc_ws/install:cached" \
+  --workdir /wb_humanoid_mpc_ws \
+  wb-humanoid-mpc:dev \
+  bash -c "chown -R ubuntu:ubuntu /wb_humanoid_mpc_ws/build /wb_humanoid_mpc_ws/install && exec su ubuntu -c bash"
+
+echo "Done."
+


### PR DESCRIPTION
I have added the results related to memory usage across different PARALLEL_JOBS values. I’ve also included two bash scripts:  - image_build.bash — for building the Docker image
- launch_wb_mpc.bash — for running the container with proper mount and GUI settings